### PR TITLE
Fixed Typescript error in Contributors.tsx that was breaking the buil…

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -26,7 +26,7 @@ export default function Projects() {
                 imgSrc={d.imgSrc}
                 href={d.href}
                 repository={d.repository}
-                contributorsHref={`projects/${d.name}/${d.contributorsHref}`}
+                contributorsHref={`projects/${d.name}${d.contributorsHref}`}
                 contributors={d.contributors}
               />
             ))}

--- a/components/Contributors.tsx
+++ b/components/Contributors.tsx
@@ -22,8 +22,9 @@ type projectsDataType =
 function Contributors() {
   const [contributors, setContributors] = useState<projectsDataType>({})
   const pathname = usePathname()
-  const projectName = useMemo(() => /^\/projects\/(.+)\/contributors$/i, [])
-  const match: string | null = pathname.match(projectName)[1]
+  const re = useMemo(() => /^\/projects\/(.+)\/contributors$/i, [])
+  const projectName: RegExpMatchArray | null = pathname.match(re)
+  const match: string | null = projectName && projectName[1]
 
   useEffect(() => {
     for (const i in projectsData) {

--- a/data/projectsData.ts
+++ b/data/projectsData.ts
@@ -33,7 +33,7 @@ const projectsData = [
       'Benny Van': { github: 'https://github.com/bennyv8', role: 'Architect Owner' },
       'Thanh Ly': { github: 'https://github.com/thanhgly', role: 'Full Stack Software Engineer' },
       'San Chui': {
-        github: 'https://"github".com/Allen3021',
+        github: 'https://github.com/Allen3021',
         role: 'Full Stack Software Engineer',
       },
       'Patty Long': {


### PR DESCRIPTION
### Category
---
| | PR Type |
| ------------- | ------------- |
| ✔️ | Bug Fix |
| | New Feature  |
| | Refactor  |
| | Update Deps  |
| | Documentation  |

### Description
---
- _Fixed Typescript error in `Contributors.tsx` that was breaking the build. Had to update the regular expression that's being used to compare the URL slug with the `projectsData` fetched project name to require a string or null_
- _Check to make sure the regular expression returned real data in `useEffect` call, and then iterate over projectsData to grab the correct contributors list for rendering_
- Fixed a typo in one of the Github profile links in `projectsData.ts` to fix broken link_
